### PR TITLE
Support non standard doctype tag

### DIFF
--- a/dist/parser.js
+++ b/dist/parser.js
@@ -180,7 +180,16 @@ var Parser = function (_Writable) {
           attributes = _parseTagString2.attributes;
 
       if (name === null) {
-        this.emit(EVENTS.ERROR, new Error("Failed to parse name for tag" + tag));
+        console.log(tag, name, attributes);
+        // Support for non standard doctype tags
+        if (tag.toLowerCase().startsWith('!doctype')) {
+          name = '!doctype';
+          if (attributes === null) {
+            attributes = {};
+          }
+        } else {
+          this.emit(EVENTS.ERROR, new Error("Failed to parse name for tag" + tag));
+        }
       }
 
       if (this.tagType && this.tagType == TAG_TYPE.OPENING) {

--- a/dist/parser.js
+++ b/dist/parser.js
@@ -180,7 +180,6 @@ var Parser = function (_Writable) {
           attributes = _parseTagString2.attributes;
 
       if (name === null) {
-        console.log(tag, name, attributes);
         // Support for non standard doctype tags
         if (tag.toLowerCase().startsWith('!doctype')) {
           name = '!doctype';

--- a/src/parser.js
+++ b/src/parser.js
@@ -208,10 +208,18 @@ const Parser = (function(_Writable) {
           attributes = _parseTagString2.attributes;
 
         if (name === null) {
-          this.emit(
-            EVENTS.ERROR,
-            new Error("Failed to parse name for tag" + tag)
-          );
+          // Support for non standard doctype tags
+          if (tag.toLowerCase().startsWith('!doctype')) {
+            name = '!doctype';
+            if (attributes === null) {
+              attributes = {}; 
+            }
+          } else {
+            this.emit(
+              EVENTS.ERROR,
+              new Error("Failed to parse name for tag" + tag)
+            );
+          }
         }
 
         if (this.tagType && this.tagType == TAG_TYPE.OPENING) {


### PR DESCRIPTION
Some documents can use a !DOCTYPE tag like a kind of header, i.e.
`<!DOCTYPE ProteinDatabase SYSTEM "http://pir.georgetown.edu/pirwww/xml/002/psdml.dtd">`

The proposal is to keep only !doctype as tag name and ignore attributes than cannot be parsed.

Tests has been run by adding this tag locally to the atom xml